### PR TITLE
Ability to set connection timeout & Ability to use 'IN' operator in where statements

### DIFF
--- a/config/hubspot.php
+++ b/config/hubspot.php
@@ -65,5 +65,6 @@ return [
 
     'http' => [
         'timeout' => env('HUBSPOT_HTTP_TIMEOUT', 10),
+        'connect_timeout' => env('HUBSPOT_HTTP_CONNECT_TIMEOUT', 10),
     ],
 ];

--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -32,6 +32,7 @@ class Client
     public function http(): PendingRequest
     {
         return Http::timeout(config('hubspot.http.timeout', 10))
+            ->connectTimeout(config('hubspot.http.connect_timeout', 10))
             ->withToken($this->accessToken)
             ->throw(function (Response $response, RequestException $exception) {
                 if ($response->json('category') === 'RATE_LIMITS') {

--- a/src/Api/Filter.php
+++ b/src/Api/Filter.php
@@ -37,6 +37,14 @@ class Filter
             ];
         }
 
+        if ($this->operator === 'IN') {
+            return [
+                'propertyName' => $this->property,
+                'operator'     => $this->operator,
+                'values'       => $this->value,
+            ];
+        }
+
         return array_filter([
             'propertyName' => $this->property,
             'operator'     => $this->operator,


### PR DESCRIPTION
Few updates from me, I had a need for the connectTimeout to be set as well as needed to use the 'IN' operator

example:

```
$deals = Deal::take($limit)
                ->where('dealstage', 'IN', ['teststage', 'testingstage'])
                ->get();
```