### PR TITLE
Fix PHP deprecation warning for explode() function

### DIFF
--- a/src/Crm/Property.php
+++ b/src/Crm/Property.php
@@ -47,7 +47,7 @@ class Property extends Model
             'date'        => Carbon::parse($value),
             'datetime'    => Carbon::parse($value),
             'number'      => $value + 0,
-            'enumeration' => explode(";", $value),
+            'enumeration' => is_null($value) ? [] : explode(";", $value),
             default       => $value,
         };
     }


### PR DESCRIPTION
Addresses the deprecation warning raised in PHP >=8.1 when passing null as the second parameter to the explode() function (https://www.php.net/manual/en/migration81.deprecated.php).