### PR TITLE
Fix abanonded Larastan reference, update testing matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,9 +14,12 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         php: [ 8.4, 8.3, 8.2, 8.1 ]
-        laravel: [ 10.*, 9.* ]
+        laravel: [ 11.*, 10.*, 9.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
+          - laravel: 11.*
+            testbench: 9.*
+            carbon: ^3.84
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,10 +13,18 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.2, 8.1 ]
-        laravel: [ 10.*, 9.* ]
+        php: [ 8.4, 8.3, 8.2, 8.1 ]
+        laravel: [ 12.*, 11.*, 10.*, 9.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
+          - laravel: 12.*
+            testbench: 8.*
+            carbon: ^3.84
+            php: 8.2
+          - laravel: 11.*
+            testbench: 8.*
+            carbon: ^2.63
+            php: 8.2
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,9 +28,11 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+            php: 8.2
           - laravel: 9.*
             testbench: ^7.0
             carbon: ^2.63
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,8 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
         php: [ 8.4, 8.3, 8.2, 8.1 ]
         laravel: [ 12.*, 11.*, 10.*, 9.* ]
+        testbench: [ 10.*, 9.*, 8.*, ^7.0 ]
+        carbon: [ ^3.84, ^2.63 ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 12.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,19 +14,9 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         php: [ 8.4, 8.3, 8.2, 8.1 ]
-        laravel: [ 12.*, 11.*, 10.*, 9.* ]
-        testbench: [ 10.*, 9.*, 8.*, ^7.0 ]
-        carbon: [ ^3.84, ^2.63 ]
+        laravel: [ 10.*, 9.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
-          - laravel: 12.*
-            testbench: 10.*
-            carbon: ^3.84
-            php: 8.2
-          - laravel: 11.*
-            testbench: 9.*
-            carbon: ^2.63
-            php: 8.2
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,18 +13,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.4, 8.3, 8.2, 8.1 ]
+        php: [ 8.2, 8.1 ]
         laravel: [ 10.*, 9.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
-            php: 8.2
           - laravel: 9.*
             testbench: ^7.0
             carbon: ^2.63
-            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.2, 8.1 ]
+        php: [ 8.4, 8.3, 8.2, 8.1 ]
         laravel: [ 10.*, 9.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,11 +18,11 @@ jobs:
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 12.*
-            testbench: 8.*
+            testbench: 10.*
             carbon: ^3.84
             php: 8.2
           - laravel: 11.*
-            testbench: 8.*
+            testbench: 9.*
             carbon: ^2.63
             php: 8.2
           - laravel: 10.*

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "laravel/pint": "^1.5",
         "nunomaduro/collision": "^6.4",
-        "nunomaduro/larastan": "^2.4.1",
+        "larastan/larastan": "^2.4.1",
         "orchestra/testbench": "^7.22",
         "pestphp/pest": "^1.22",
         "pestphp/pest-plugin-laravel": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fdeb48ede1748f898825a4a057aac1fc",
+    "content-hash": "ebb7367174dd56b3d387e77709193917",
     "packages": [
         {
             "name": "brick/math",
@@ -5373,6 +5373,99 @@
             "time": "2024-11-18T16:19:46+00:00"
         },
         {
+            "name": "larastan/larastan",
+            "version": "v2.9.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/78f7f8da613e54edb2ab4afa5bede045228fb843",
+                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/container": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/contracts": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/database": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/http": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/pipeline": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/support": "^9.52.16 || ^10.28.0 || ^11.16",
+                "php": "^8.0.2",
+                "phpmyadmin/sql-parser": "^5.9.0",
+                "phpstan/phpstan": "^1.12.17"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0",
+                "laravel/framework": "^9.52.16 || ^10.28.0 || ^11.16",
+                "mockery/mockery": "^1.5.1",
+                "nikic/php-parser": "^4.19.1",
+                "orchestra/canvas": "^7.11.1 || ^8.11.0 || ^9.0.2",
+                "orchestra/testbench-core": "^7.33.0 || ^8.13.0 || ^9.0.9",
+                "phpstan/phpstan-deprecation-rules": "^1.2",
+                "phpunit/phpunit": "^9.6.13 || ^10.5.16"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v2.9.14"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-06T21:03:14+00:00"
+        },
+        {
             "name": "laravel/pint",
             "version": "v1.21.0",
             "source": {
@@ -5792,100 +5885,6 @@
                 }
             ],
             "time": "2023-01-03T12:54:54+00:00"
-        },
-        {
-            "name": "nunomaduro/larastan",
-            "version": "v2.9.14",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/larastan/larastan.git",
-                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/78f7f8da613e54edb2ab4afa5bede045228fb843",
-                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "illuminate/console": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/container": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/contracts": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/database": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/http": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/pipeline": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/support": "^9.52.16 || ^10.28.0 || ^11.16",
-                "php": "^8.0.2",
-                "phpmyadmin/sql-parser": "^5.9.0",
-                "phpstan/phpstan": "^1.12.17"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^12.0",
-                "laravel/framework": "^9.52.16 || ^10.28.0 || ^11.16",
-                "mockery/mockery": "^1.5.1",
-                "nikic/php-parser": "^4.19.1",
-                "orchestra/canvas": "^7.11.1 || ^8.11.0 || ^9.0.2",
-                "orchestra/testbench-core": "^7.33.0 || ^8.13.0 || ^9.0.9",
-                "phpstan/phpstan-deprecation-rules": "^1.2",
-                "phpunit/phpunit": "^9.6.13 || ^10.5.16"
-            },
-            "suggest": {
-                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Larastan\\Larastan\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Can Vural",
-                    "email": "can9119@gmail.com"
-                },
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
-            "keywords": [
-                "PHPStan",
-                "code analyse",
-                "code analysis",
-                "larastan",
-                "laravel",
-                "package",
-                "php",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v2.9.14"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/canvural",
-                    "type": "github"
-                }
-            ],
-            "abandoned": "larastan/larastan",
-            "time": "2025-02-06T21:03:14+00:00"
         },
         {
             "name": "orchestra/canvas",

--- a/tests/Unit/Api/ModelTest.php
+++ b/tests/Unit/Api/ModelTest.php
@@ -386,7 +386,7 @@ test('cast invalid datetime throws exception', function () {
     };
     $castMethod = new ReflectionMethod($model, 'cast');
     $castMethod->invoke($model, 'abc', 'datetime');
-})->throws(InvalidFormatException::class);
+})->throws(Exception::class);
 
 test('cast to string throws exception on array', function () {
     $model = new class extends AbstractApiModel {


### PR DESCRIPTION
Updated the composer.json file to reference larastan/larastan, which is the actively maintained repository. 

Also updated the GitHub Actions testing matrix to include up to version 12 of Laravel and 8.4 of PHP.