### PR TITLE
Larastan Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "laravel/pint": "^1.5",
         "nunomaduro/collision": "^6.4",
-        "larastan/larastan": "^2.4.1",
+        "larastan/larastan": "^2.9.14",
         "orchestra/testbench": "^7.22",
         "pestphp/pest": "^1.22",
         "pestphp/pest-plugin-laravel": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "laravel/pint": "^1.5",
         "nunomaduro/collision": "^6.4",
-        "nunomaduro/larastan": "^2.4.1",
+        "larastan/larastan": "^2.4.1",
         "orchestra/testbench": "^7.22",
         "pestphp/pest": "^1.22",
         "pestphp/pest-plugin-laravel": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ebb7367174dd56b3d387e77709193917",
+    "content-hash": "edbd2c865c550a5d0a07c4fd3efa8ebc",
     "packages": [
         {
             "name": "brick/math",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fdeb48ede1748f898825a4a057aac1fc",
+    "content-hash": "ebb7367174dd56b3d387e77709193917",
     "packages": [
         {
             "name": "brick/math",
@@ -5373,6 +5373,99 @@
             "time": "2024-11-18T16:19:46+00:00"
         },
         {
+            "name": "larastan/larastan",
+            "version": "v2.9.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/78f7f8da613e54edb2ab4afa5bede045228fb843",
+                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/container": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/contracts": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/database": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/http": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/pipeline": "^9.52.16 || ^10.28.0 || ^11.16",
+                "illuminate/support": "^9.52.16 || ^10.28.0 || ^11.16",
+                "php": "^8.0.2",
+                "phpmyadmin/sql-parser": "^5.9.0",
+                "phpstan/phpstan": "^1.12.17"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0",
+                "laravel/framework": "^9.52.16 || ^10.28.0 || ^11.16",
+                "mockery/mockery": "^1.5.1",
+                "nikic/php-parser": "^4.19.1",
+                "orchestra/canvas": "^7.11.1 || ^8.11.0 || ^9.0.2",
+                "orchestra/testbench-core": "^7.33.0 || ^8.13.0 || ^9.0.9",
+                "phpstan/phpstan-deprecation-rules": "^1.2",
+                "phpunit/phpunit": "^9.6.13 || ^10.5.16"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v2.9.14"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-06T21:03:14+00:00"
+        },
+        {
             "name": "laravel/pint",
             "version": "v1.21.0",
             "source": {
@@ -5792,100 +5885,6 @@
                 }
             ],
             "time": "2023-01-03T12:54:54+00:00"
-        },
-        {
-            "name": "nunomaduro/larastan",
-            "version": "v2.9.14",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/larastan/larastan.git",
-                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/78f7f8da613e54edb2ab4afa5bede045228fb843",
-                "reference": "78f7f8da613e54edb2ab4afa5bede045228fb843",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "illuminate/console": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/container": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/contracts": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/database": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/http": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/pipeline": "^9.52.16 || ^10.28.0 || ^11.16",
-                "illuminate/support": "^9.52.16 || ^10.28.0 || ^11.16",
-                "php": "^8.0.2",
-                "phpmyadmin/sql-parser": "^5.9.0",
-                "phpstan/phpstan": "^1.12.17"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^12.0",
-                "laravel/framework": "^9.52.16 || ^10.28.0 || ^11.16",
-                "mockery/mockery": "^1.5.1",
-                "nikic/php-parser": "^4.19.1",
-                "orchestra/canvas": "^7.11.1 || ^8.11.0 || ^9.0.2",
-                "orchestra/testbench-core": "^7.33.0 || ^8.13.0 || ^9.0.9",
-                "phpstan/phpstan-deprecation-rules": "^1.2",
-                "phpunit/phpunit": "^9.6.13 || ^10.5.16"
-            },
-            "suggest": {
-                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Larastan\\Larastan\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Can Vural",
-                    "email": "can9119@gmail.com"
-                },
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
-            "keywords": [
-                "PHPStan",
-                "code analyse",
-                "code analysis",
-                "larastan",
-                "laravel",
-                "package",
-                "php",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v2.9.14"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/canvural",
-                    "type": "github"
-                }
-            ],
-            "abandoned": "larastan/larastan",
-            "time": "2025-02-06T21:03:14+00:00"
         },
         {
             "name": "orchestra/canvas",

--- a/src/Api/Collection.php
+++ b/src/Api/Collection.php
@@ -10,7 +10,7 @@ class Collection extends \Illuminate\Support\Collection
     protected int $total = 0;
     protected $after;
 
-    public static function hydrate(array $response, string $className): static
+    public static function hydrate(array $response, string $className): self
     {
         $instance = new static($response['results']);
         $instance = $instance->map(fn($payload) => $className::hydrate($payload));

--- a/src/Api/Interfaces/ModelInterface.php
+++ b/src/Api/Interfaces/ModelInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace STS\HubSpot\Api\Interfaces;
+
+interface ModelInterface
+{
+    public function __construct(array $properties = []);
+}

--- a/src/Api/Model.php
+++ b/src/Api/Model.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 use STS\HubSpot\Api\Concerns\HasAssociations;
 use STS\HubSpot\Api\Concerns\HasPropertyDefinitions;
+use STS\HubSpot\Api\Interfaces\ModelInterface;
 use STS\HubSpot\Crm\Owner;
 use STS\HubSpot\Crm\Property;
 use STS\HubSpot\Facades\HubSpot;
@@ -16,7 +17,7 @@ use STS\HubSpot\Facades\HubSpot;
 /**
  * @property-read Collection $definitions
  */
-abstract class Model
+abstract class Model implements ModelInterface
 {
     use ForwardsCalls, Macroable, HasAssociations, HasPropertyDefinitions;
 
@@ -62,7 +63,7 @@ abstract class Model
         $this->fill($properties);
     }
 
-    public static function hydrate(array $payload = []): static
+    public static function hydrate(array $payload = []): self
     {
         $instance = new static;
         $instance->init($payload);


### PR DESCRIPTION

1. Larastan has moved from `nunomaduro/larastan` to `larastan/larastan`
2. Running `vendor/bin/phpstan analyze src/` found 4 potential `Unsafe usage of new static()` errors