### PR TITLE
Add Invoice and Subscription models for HubSpot billing support

### DIFF
--- a/config/hubspot.php
+++ b/config/hubspot.php
@@ -41,6 +41,16 @@ return [
         'include_associations' => ['companies','contacts','deals','tickets'],
     ],
 
+    'invoices' => [
+        'include_properties' => [],
+        'include_associations' => ['companies','contacts','quotes'],
+    ],
+
+    'subscriptions' => [
+        'include_properties' => [],
+        'include_associations' => ['companies','contacts','quotes'],
+    ],
+
     'calls' => [
         'include_properties' => ['hs_call_title','hubspot_owner_id','hs_call_body','hs_call_direction','hs_call_callee_object_id','hs_call_callee_object_type_id','hs_call_disposition','hs_call_duration','hs_call_from_number','hs_call_to_number'],
         'include_associations' => ['companies','contacts','deals','tickets'],

--- a/src/Crm/Invoice.php
+++ b/src/Crm/Invoice.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace STS\HubSpot\Crm;
+
+use STS\HubSpot\Api\Association;
+use STS\HubSpot\Api\Collection;
+use STS\HubSpot\Api\Model;
+
+/**
+ * @method Association companies()
+ * @method Association contacts()
+ * @method Association quotes()
+ * @method Association line_items()
+ * @property-read Company|null $company
+ * @property-read Collection $companies
+ * @property-read Contact|null $contact
+ * @property-read Collection $contacts
+ * @property-read Quote|null $quote
+ * @property-read Collection $quotes 
+ * @property-read LineItems|null $line_item
+ * @property-read Collection $line_items
+ */
+class Invoice extends Model
+{
+    protected string $type = "invoices";
+}

--- a/src/Crm/Subscription.php
+++ b/src/Crm/Subscription.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace STS\HubSpot\Crm;
+
+use STS\HubSpot\Api\Association;
+use STS\HubSpot\Api\Collection;
+use STS\HubSpot\Api\Model;
+
+/**
+ * @method Association companies()
+ * @method Association contacts()
+ * @method Association quotes()
+ * @method Association line_items()
+ * @property-read Company|null $company
+ * @property-read Collection $companies
+ * @property-read Contact|null $contact
+ * @property-read Collection $contacts
+ * @property-read Quote|null $quote
+ * @property-read Collection $quotes
+ * @property-read LineItems|null $line_item
+ * @property-read Collection $line_items
+ */
+class Subscription extends Model
+{
+    protected string $type = "subscriptions";
+}


### PR DESCRIPTION
This PR introduces two new models: `Invoice` and `Subscription`, to support HubSpot’s billing-related CRM objects.

### ✨ What’s included:

- `STS\HubSpot\Crm\Invoice`: Represents the HubSpot Invoice object
- `STS\HubSpot\Crm\Subscription`: Represents the HubSpot Subscription object
- Both follow the existing architecture used for models like `Quote` and `LineItem`

### 🔧 Implementation Notes:

- Located under `src/Crm/`
- Designed for consistency with the package’s existing API model structure
- Tested locally in standalone CLI usage against the live HubSpot API

### 📚 References:

- HubSpot Developer Docs:
  - [Invoices API](https://developers.hubspot.com/docs/reference/api/crm/commerce/invoices)
  - [Subscriptions API](https://developers.hubspot.com/docs/reference/api/crm/commerce/subscriptions)

Thanks for reviewing! 🚀
